### PR TITLE
chore: update rust sgx sdk

### DIFF
--- a/prepare-1.1.5-intel-2.17.0.sh
+++ b/prepare-1.1.5-intel-2.17.0.sh
@@ -6,7 +6,7 @@
 # https://download.01.org/intel-sgx/sgx-linux/2.17/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf
 export INTEL_SGX_SDK_INSTALLER_URL="https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.17.100.3.bin"
 
-# Rust SGX SDK 1.1.4
+# Rust SGX SDK 1.1.5
 export RUST_SGX_SDK_REVISION="d2d339cbb005f676bb700059bd51dc689c025f6b"
 
 "$(dirname "$0")"/prepare.sh

--- a/prepare-1.1.5-intel-2.17.0.sh
+++ b/prepare-1.1.5-intel-2.17.0.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# Intel SGX SDK 2.17.0
+# https://01.org/intel-softwareguard-extensions/downloads/intel-sgx-linux-2.17-release
+# https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu20.04-server/
+# https://download.01.org/intel-sgx/sgx-linux/2.17/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf
+export INTEL_SGX_SDK_INSTALLER_URL="https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.17.100.3.bin"
+
+# Rust SGX SDK 1.1.4
+export RUST_SGX_SDK_REVISION="d2d339cbb005f676bb700059bd51dc689c025f6b"
+
+"$(dirname "$0")"/prepare.sh


### PR DESCRIPTION
### Overview

Update to Rust SGX SDK 1.1.5 and Intel SGX SDK 2.17.0

### Required Toolchain

It is crucial to note that use of the new SDKs requires the `nightly-2022-02-23` Rust toolchain.  In an SGX workspace this may be achieved via an [override](https://rust-lang.github.io/rustup/overrides.html) by running
```sh
$ rustup override set nightly-2022-02-23
```
To make this change persistent across checkouts, set the toolchain above in a `rust-toolchain.toml` file within the SGX workspace, as explained [here](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file).